### PR TITLE
Fix/quick notes menu

### DIFF
--- a/src/app/body/create-new-task/create-new-task.component.ts
+++ b/src/app/body/create-new-task/create-new-task.component.ts
@@ -71,11 +71,18 @@ export class CreateNewTaskComponent implements OnInit {
     this.todayDate = this.toolsService.date();
     this.time = this.toolsService.time();
     this.parentTaskId = this.popupHandlerService.parentTaskId;
+    this.title = this.popupHandlerService.quickNotesTitle;
+    this.description = this.popupHandlerService.quickNotesDescription;
   }
 
   private _filter(value: string): string[] {
     const filterValue = value.toLowerCase();
     return this.teamMembers.filter(option => option.toLowerCase().includes(filterValue));
+  }
+
+  createTaskFromNotes(notesTitle:string, notesDescription:string){
+    this.title = notesTitle;
+    this.description = notesDescription;
   }
 
   readTeamData(teamId :string){

--- a/src/app/body/create-new-task/create-new-task.component.ts
+++ b/src/app/body/create-new-task/create-new-task.component.ts
@@ -71,18 +71,11 @@ export class CreateNewTaskComponent implements OnInit {
     this.todayDate = this.toolsService.date();
     this.time = this.toolsService.time();
     this.parentTaskId = this.popupHandlerService.parentTaskId;
-    this.title = this.popupHandlerService.quickNotesTitle;
-    this.description = this.popupHandlerService.quickNotesDescription;
   }
 
   private _filter(value: string): string[] {
     const filterValue = value.toLowerCase();
     return this.teamMembers.filter(option => option.toLowerCase().includes(filterValue));
-  }
-
-  createTaskFromNotes(notesTitle:string, notesDescription:string){
-    this.title = notesTitle;
-    this.description = notesDescription;
   }
 
   readTeamData(teamId :string){

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.css
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.css
@@ -27,4 +27,12 @@
   #icon {
       color: var(--text);
       cursor: pointer;
+      flex-grow: 0 !important;
   }
+  
+#create{
+  padding: 5px 0px 0px 0px;
+  cursor: pointer;
+  text-align: center;
+ }
+

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.css
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.css
@@ -27,4 +27,11 @@
   #icon {
       color: var(--text);
       cursor: pointer;
+      flex-grow: 0 !important;
   }
+  
+#create{
+  padding: 5px 0px 0px 0px;
+  cursor: pointer;
+  text-align: center;
+ }

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.css
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.css
@@ -27,12 +27,4 @@
   #icon {
       color: var(--text);
       cursor: pointer;
-      flex-grow: 0 !important;
   }
-  
-#create{
-  padding: 5px 0px 0px 0px;
-  cursor: pointer;
-  text-align: center;
- }
-

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.html
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.html
@@ -1,26 +1,23 @@
-<div class="card" style="width: 36rem">
+<div class="card" style="width: 36rem;">
     <div class="card-header">
         <div class="row">
-            <div class="col-8">
-                <input type="text" class="form-control form-control-sm" [(ngModel)]="title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title"/>
+            <div class="col 10">
+                <input type="text" class="form-control form-control-sm" [(ngModel)]="title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
             </div>
-            <div class="col-3" id="create">
-                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
-            </div>
-            <div class="col-1">
-                <mat-icon fontSet="material-icons" id="icon" class="float-right align-middle" (click)="close()">
+            <div class="col">
+                <mat-icon fontSet="material-icons" id="icon" class="float-right" (click)="close()">
                     close
                 </mat-icon>
             </div>
         </div>
     </div>
     <div class="card-body">
-        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="notesContent" [ngModelOptions]="{ standalone: true }" placeholder="Write a note..."></textarea>
+        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="notesContent" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
         <div class="row pt-4">
             <div class="col">
                 <button class="btn btn-success float-right" (click)="addNote()">save</button>
             </div>
         </div>
     </div>
-    <app-loader *ngIf="enableLoader"></app-loader>
+<app-loader *ngIf="enableLoader"></app-loader>
 </div>

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.html
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.html
@@ -1,23 +1,26 @@
-<div class="card" style="width: 36rem;">
+<div class="card" style="width: 36rem">
     <div class="card-header">
         <div class="row">
-            <div class="col 10">
-                <input type="text" class="form-control form-control-sm" [(ngModel)]="title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
+            <div class="col-8">
+                <input type="text" class="form-control form-control-sm" [(ngModel)]="title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title"/>
             </div>
-            <div class="col">
-                <mat-icon fontSet="material-icons" id="icon" class="float-right" (click)="close()">
+            <div class="col-3" id="create">
+                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
+            </div>
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" id="icon" class="float-right align-middle" (click)="close()">
                     close
                 </mat-icon>
             </div>
         </div>
     </div>
     <div class="card-body">
-        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="notesContent" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
+        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="notesContent" [ngModelOptions]="{ standalone: true }" placeholder="Write a note..."></textarea>
         <div class="row pt-4">
             <div class="col">
                 <button class="btn btn-success float-right" (click)="addNote()">save</button>
             </div>
         </div>
     </div>
-<app-loader *ngIf="enableLoader"></app-loader>
+    <app-loader *ngIf="enableLoader"></app-loader>
 </div>

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
@@ -1,8 +1,10 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { AngularFireFunctions } from '@angular/fire/compat/functions';
+import { $ } from 'protractor';
 import { map } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { ToolsService } from 'src/app/services/tool/tools.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 @Component({
   selector: 'app-addnew-note',
@@ -12,16 +14,24 @@ import { ToolsService } from 'src/app/services/tool/tools.service';
 export class AddnewNoteComponent implements OnInit {
 
   @Output() addNoteCompleted = new EventEmitter<boolean>();
-
+  @Output() showList = new EventEmitter();
   title: string = ""
   notesContent: string = ""
 
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService,public popupHandlerService: PopupHandlerService) { }
 
   ngOnInit(): void {
   }
+  createTask(){
+    this.popupHandlerService.createNewTaskEnabled= true;
+    this.popupHandlerService.resetTaskIds();
+    this.popupHandlerService.quickNotesTitle = this.title;
+    this.popupHandlerService.quickNotesDescription = this.notesContent;
+    this.addNote();
+    }
+  
 
   addNote() {
     const uid = this.authService.getLoggedInUser();
@@ -39,6 +49,8 @@ export class AddnewNoteComponent implements OnInit {
       });
     }
   }
+
+
 
   close() {
     this.addNoteCompleted.emit(true);

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
@@ -1,10 +1,8 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { AngularFireFunctions } from '@angular/fire/compat/functions';
-import { $ } from 'protractor';
 import { map } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { ToolsService } from 'src/app/services/tool/tools.service';
-import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 @Component({
   selector: 'app-addnew-note',
@@ -14,24 +12,16 @@ import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handle
 export class AddnewNoteComponent implements OnInit {
 
   @Output() addNoteCompleted = new EventEmitter<boolean>();
-  @Output() showList = new EventEmitter();
+
   title: string = ""
   notesContent: string = ""
 
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService,public popupHandlerService: PopupHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService) { }
 
   ngOnInit(): void {
   }
-  createTask(){
-    this.popupHandlerService.createNewTaskEnabled= true;
-    this.popupHandlerService.resetTaskIds();
-    this.popupHandlerService.quickNotesTitle = this.title;
-    this.popupHandlerService.quickNotesDescription = this.notesContent;
-    this.addNote();
-    }
-  
 
   addNote() {
     const uid = this.authService.getLoggedInUser();
@@ -49,8 +39,6 @@ export class AddnewNoteComponent implements OnInit {
       });
     }
   }
-
-
 
   close() {
     this.addNoteCompleted.emit(true);

--- a/src/app/body/quick-notes/edit-note/edit-note.component.css
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.css
@@ -27,12 +27,4 @@ input:focus {
 #icon {
     color: var(--text);
     cursor: pointer;
-    flex-grow: 0 !important;
 }
-
-#create{
- padding: 5px 0px 0px 0px;
- cursor: pointer;
- text-align: center;
-}
-  

--- a/src/app/body/quick-notes/edit-note/edit-note.component.css
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.css
@@ -27,4 +27,12 @@ input:focus {
 #icon {
     color: var(--text);
     cursor: pointer;
+    flex-grow: 0 !important;
 }
+
+#create{
+ padding: 5px 0px 0px 0px;
+ cursor: pointer;
+ text-align: center;
+}
+  

--- a/src/app/body/quick-notes/edit-note/edit-note.component.css
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.css
@@ -25,6 +25,14 @@ input:focus {
 }
 
 #icon {
-    color: var(--text);
-    cursor: pointer;
+  color: var(--text);
+  cursor: pointer;
+  flex-grow: 0 !important;
 }
+
+#create{
+padding: 5px 0px 0px 0px;
+cursor: pointer;
+text-align: center;
+}
+

--- a/src/app/body/quick-notes/edit-note/edit-note.component.html
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.html
@@ -1,34 +1,23 @@
 <div class="card" style="width: 36rem;">
-    <div class="card-header">
-        <div class="row">
-            <div class="col-7">
-                <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title"
-                    [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
-            </div>
-            <div class="col-3" id="create">
-                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
-            </div>
-            <div class="col-1">
-                <mat-icon fontSet="material-icons" title="Add New Note" class="float-right" id="icon" (click)="addNote()">
-                    add_box
-                </mat-icon>
-            </div>
-
-            <div class="col-1">
-                <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
-                    close
-                </mat-icon>
-            </div>
-        </div>
-    </div>
-    <div class="card-body">
-        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note"
-            [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
-        <div class="row pt-4">
-            <div class="col">
-                <button class="btn btn-success float-right" (click)="saveNote()">save</button>
-            </div>
-        </div>
-    </div>
-    <app-loader *ngIf="enableLoader"></app-loader>
+  <div class="card-header">
+      <div class="row">
+          <div class="col-10">
+              <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
+          </div>
+          <div class="col">
+              <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
+                  close
+              </mat-icon>
+          </div>
+      </div>
+  </div>
+  <div class="card-body">
+          <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
+      <div class="row pt-4">
+          <div class="col">
+              <button class="btn btn-success float-right" (click)="saveNote()">save</button>
+          </div>
+      </div>
+  </div>
+  <app-loader *ngIf="enableLoader"></app-loader>
 </div>

--- a/src/app/body/quick-notes/edit-note/edit-note.component.html
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.html
@@ -1,23 +1,34 @@
 <div class="card" style="width: 36rem;">
-  <div class="card-header">
-      <div class="row">
-          <div class="col-10">
-              <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
-          </div>
-          <div class="col">
-              <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
-                  close
-              </mat-icon>
-          </div>
-      </div>
-  </div>
-  <div class="card-body">
-          <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
-      <div class="row pt-4">
-          <div class="col">
-              <button class="btn btn-success float-right" (click)="saveNote()">save</button>
-          </div>
-      </div>
-  </div>
-  <app-loader *ngIf="enableLoader"></app-loader>
+    <div class="card-header">
+        <div class="row">
+            <div class="col-7">
+                <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title"
+                    [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
+            </div>
+            <div class="col-3" id="create">
+                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
+            </div>
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" title="Add New Note" class="float-right" id="icon" (click)="addNote()">
+                    add_box
+                </mat-icon>
+            </div>
+
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
+                    close
+                </mat-icon>
+            </div>
+        </div>
+    </div>
+    <div class="card-body">
+        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note"
+            [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
+        <div class="row pt-4">
+            <div class="col">
+                <button class="btn btn-success float-right" (click)="saveNote()">save</button>
+            </div>
+        </div>
+    </div>
+    <app-loader *ngIf="enableLoader"></app-loader>
 </div>

--- a/src/app/body/quick-notes/edit-note/edit-note.component.html
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.html
@@ -1,10 +1,19 @@
 <div class="card" style="width: 36rem;">
   <div class="card-header">
       <div class="row">
-          <div class="col-10">
-              <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
-          </div>
-          <div class="col">
+          <div class="col-7">
+            <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
+            </div>
+            <div class="col-3" id="create">
+                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
+            </div>
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" title="Add New Note" class="float-right" id="icon" (click)="addNote()">
+                    add_box
+                </mat-icon>
+            </div>
+
+          <div class="col-1">
               <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
                   close
               </mat-icon>
@@ -12,7 +21,7 @@
       </div>
   </div>
   <div class="card-body">
-          <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
+        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
       <div class="row pt-4">
           <div class="col">
               <button class="btn btn-success float-right" (click)="saveNote()">save</button>

--- a/src/app/body/quick-notes/edit-note/edit-note.component.ts
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.ts
@@ -6,7 +6,6 @@ import { ToolsService } from 'src/app/services/tool/tools.service';
 import { map, Observable } from 'rxjs';
 import { Router } from '@angular/router';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
-import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 
 @Component({
@@ -17,25 +16,17 @@ import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handle
 export class EditNoteComponent implements OnInit {
 
   @Output() editNoteCompleted = new EventEmitter<boolean>();
-  @Output() addNewNote = new EventEmitter();
   @Input('note') note: QuickNote;
   public quickNoteObservable: Observable<QuickNote>
   componentName:string = "QUICK-NOTES"
   editNote: QuickNote
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService,public popupHandlerService: PopupHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService) { }
 
   ngOnInit(): void {
     
   }
-  createTask(){
-    this.popupHandlerService.createNewTaskEnabled= true;
-    this.popupHandlerService.resetTaskIds();
-    this.popupHandlerService.quickNotesTitle = this.note.Title;
-    this.popupHandlerService.quickNotesDescription = this.note.Note;
-    this.saveNote();
-    }
 
   async saveNote() {
     const uid = this.authService.getLoggedInUser();
@@ -53,10 +44,6 @@ export class EditNoteComponent implements OnInit {
       console.error("Error", error);
     }
     this.editNoteCompleted.emit(true);
-  }
-
-  addNote(){
-    this.addNewNote.emit();
   }
 
   close() {

--- a/src/app/body/quick-notes/edit-note/edit-note.component.ts
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.ts
@@ -6,6 +6,7 @@ import { ToolsService } from 'src/app/services/tool/tools.service';
 import { map, Observable } from 'rxjs';
 import { Router } from '@angular/router';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 
 @Component({
@@ -16,17 +17,25 @@ import { ErrorHandlerService } from 'src/app/services/error-handler/error-handle
 export class EditNoteComponent implements OnInit {
 
   @Output() editNoteCompleted = new EventEmitter<boolean>();
+  @Output() addNewNote = new EventEmitter();
   @Input('note') note: QuickNote;
   public quickNoteObservable: Observable<QuickNote>
   componentName:string = "QUICK-NOTES"
   editNote: QuickNote
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService,public popupHandlerService: PopupHandlerService) { }
 
   ngOnInit(): void {
     
   }
+  createTask(){
+    this.popupHandlerService.createNewTaskEnabled= true;
+    this.popupHandlerService.resetTaskIds();
+    this.popupHandlerService.quickNotesTitle = this.note.Title;
+    this.popupHandlerService.quickNotesDescription = this.note.Note;
+    this.saveNote();
+    }
 
   async saveNote() {
     const uid = this.authService.getLoggedInUser();
@@ -46,6 +55,10 @@ export class EditNoteComponent implements OnInit {
     this.editNoteCompleted.emit(true);
   }
 
+  addNote(){
+    this.addNewNote.emit();
+  }
+  
   close() {
     this.editNoteCompleted.emit(true);
   }

--- a/src/app/body/quick-notes/edit-note/edit-note.component.ts
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.ts
@@ -6,6 +6,7 @@ import { ToolsService } from 'src/app/services/tool/tools.service';
 import { map, Observable } from 'rxjs';
 import { Router } from '@angular/router';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 
 @Component({
@@ -16,17 +17,25 @@ import { ErrorHandlerService } from 'src/app/services/error-handler/error-handle
 export class EditNoteComponent implements OnInit {
 
   @Output() editNoteCompleted = new EventEmitter<boolean>();
+  @Output() addNewNote = new EventEmitter();
   @Input('note') note: QuickNote;
   public quickNoteObservable: Observable<QuickNote>
   componentName:string = "QUICK-NOTES"
   editNote: QuickNote
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService,public popupHandlerService: PopupHandlerService) { }
 
   ngOnInit(): void {
     
   }
+  createTask(){
+    this.popupHandlerService.createNewTaskEnabled= true;
+    this.popupHandlerService.resetTaskIds();
+    this.popupHandlerService.quickNotesTitle = this.note.Title;
+    this.popupHandlerService.quickNotesDescription = this.note.Note;
+    this.saveNote();
+    }
 
   async saveNote() {
     const uid = this.authService.getLoggedInUser();
@@ -44,6 +53,10 @@ export class EditNoteComponent implements OnInit {
       console.error("Error", error);
     }
     this.editNoteCompleted.emit(true);
+  }
+
+  addNote(){
+    this.addNewNote.emit();
   }
 
   close() {

--- a/src/app/body/quick-notes/quick-notes.component.css
+++ b/src/app/body/quick-notes/quick-notes.component.css
@@ -1,23 +1,37 @@
 #quickNotesButton{
+    background:#5c60ec;
     display: block;
     border-radius:50px;
 	text-align:center;
-	box-shadow: 2px 2px 3px  #999;
+	box-shadow: 0px 3px 45px #5C60EC4F;
     position: fixed;
     bottom: 80px;
     right: 40px;
+    border: none !important;
 }
 
 .card {
     background-color: var(--secondary-bg);
-    position: fixed;
+    position: fixed;    
     bottom: 70px;
     right: 30px;
     color: var(--text);
+    
 }
+.card-body{
+    padding: 0.75rem 0.25rem !important;
+}
+.col{
+    flex-grow: 0 !important;
+}
+.noNotes{
+padding: auto;
+margin: auto;
 
+}
 #note {
     background-color: var(--secondary-bg);
+    border: none;
 }
 
 #note:hover {
@@ -33,4 +47,5 @@
 
 li {
     background-color: var(--secondary-bg);
+
 }

--- a/src/app/body/quick-notes/quick-notes.component.css
+++ b/src/app/body/quick-notes/quick-notes.component.css
@@ -1,37 +1,23 @@
 #quickNotesButton{
-    background:#5c60ec;
     display: block;
     border-radius:50px;
 	text-align:center;
-	box-shadow: 0px 3px 45px #5C60EC4F;
+	box-shadow: 2px 2px 3px  #999;
     position: fixed;
     bottom: 80px;
     right: 40px;
-    border: none !important;
 }
 
 .card {
     background-color: var(--secondary-bg);
-    position: fixed;    
+    position: fixed;
     bottom: 70px;
     right: 30px;
     color: var(--text);
-    
 }
-.card-body{
-    padding: 0.75rem 0.25rem !important;
-}
-.col{
-    flex-grow: 0 !important;
-}
-.noNotes{
-padding: auto;
-margin: auto;
 
-}
 #note {
     background-color: var(--secondary-bg);
-    border: none;
 }
 
 #note:hover {
@@ -47,5 +33,4 @@ margin: auto;
 
 li {
     background-color: var(--secondary-bg);
-
 }

--- a/src/app/body/quick-notes/quick-notes.component.html
+++ b/src/app/body/quick-notes/quick-notes.component.html
@@ -12,7 +12,7 @@
                     Notes
                 </div>
                 <div class="col ml-auto">
-                    <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
+                    <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()"> 
                         close
                     </mat-icon>
                 </div>
@@ -21,6 +21,7 @@
           <div class="card-body">
             <ul class="list-group list-group-flush">
                 <ng-container *ngIf="quickNoteObservable|async; else loader">
+                    <div *ngIf="noNotes;" class="noNotes">No notes Added</div>
                     <ng-container *ngFor="let item of notes">
                         <li class="list-group-item" id="note">
                             <div class="row">
@@ -50,9 +51,9 @@
 </ng-container>
 
 <ng-container *ngIf="showAddNote">
-    <app-addnew-note (addNoteCompleted)="addNoteCompleted($event)"></app-addnew-note>
+    <app-addnew-note (addNoteCompleted)="addNoteCompleted($event)" ></app-addnew-note>
 </ng-container>
 
 <ng-container *ngIf="openEditNote">
-    <app-edit-note [note]="selectedNote" (editNoteCompleted)="editNoteCompleted($event)"></app-edit-note>
+    <app-edit-note [note]="selectedNote" (addNewNote)="openAddNote()" (editNoteCompleted)="editNoteCompleted($event)"></app-edit-note>
 </ng-container>

--- a/src/app/body/quick-notes/quick-notes.component.html
+++ b/src/app/body/quick-notes/quick-notes.component.html
@@ -12,7 +12,7 @@
                     Notes
                 </div>
                 <div class="col ml-auto">
-                    <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()"> 
+                    <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
                         close
                     </mat-icon>
                 </div>
@@ -21,7 +21,6 @@
           <div class="card-body">
             <ul class="list-group list-group-flush">
                 <ng-container *ngIf="quickNoteObservable|async; else loader">
-                    <div *ngIf="noNotes;" class="noNotes">No notes Added</div>
                     <ng-container *ngFor="let item of notes">
                         <li class="list-group-item" id="note">
                             <div class="row">
@@ -51,9 +50,9 @@
 </ng-container>
 
 <ng-container *ngIf="showAddNote">
-    <app-addnew-note (addNoteCompleted)="addNoteCompleted($event)" ></app-addnew-note>
+    <app-addnew-note (addNoteCompleted)="addNoteCompleted($event)"></app-addnew-note>
 </ng-container>
 
 <ng-container *ngIf="openEditNote">
-    <app-edit-note [note]="selectedNote" (addNewNote)="openAddNote()" (editNoteCompleted)="editNoteCompleted($event)"></app-edit-note>
+    <app-edit-note [note]="selectedNote" (editNoteCompleted)="editNoteCompleted($event)"></app-edit-note>
 </ng-container>

--- a/src/app/body/quick-notes/quick-notes.component.ts
+++ b/src/app/body/quick-notes/quick-notes.component.ts
@@ -4,6 +4,7 @@ import { map, Observable } from 'rxjs';
 import { QuickNote } from 'src/app/Interface/UserInterface';
 import { AuthService } from 'src/app/services/auth.service';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 @Component({
   selector: 'app-quick-notes',
@@ -19,15 +20,17 @@ export class QuickNotesComponent implements OnInit {
   showloader: boolean = false
   showAddNote: boolean = false
   openEditNote: boolean = false
+  noNotes: boolean = true
   selectedNote: QuickNote;
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, public errorHandlerService: ErrorHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, public errorHandlerService: ErrorHandlerService, public popupHandlerService:PopupHandlerService) { }
 
   ngOnInit(): void {
   }
 
   showList() {
     this.showNotesList = true
+    this.showAddNote = false
     this.showloader = true
     const uid = this.authService.getLoggedInUser();
 
@@ -37,6 +40,12 @@ export class QuickNotesComponent implements OnInit {
       if(data) {
         this.notes = data;
       }
+      if(this.notes.length>0){
+        this.noNotes = false
+      }
+      else{
+        this.noNotes = true;
+      }
       this.showloader = false
       return data
     }));
@@ -44,6 +53,7 @@ export class QuickNotesComponent implements OnInit {
 
   openAddNote() {
     this.showNotesList = false
+    this.openEditNote= false;
     this.showAddNote = true
   }
 

--- a/src/app/body/quick-notes/quick-notes.component.ts
+++ b/src/app/body/quick-notes/quick-notes.component.ts
@@ -4,7 +4,6 @@ import { map, Observable } from 'rxjs';
 import { QuickNote } from 'src/app/Interface/UserInterface';
 import { AuthService } from 'src/app/services/auth.service';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
-import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 @Component({
   selector: 'app-quick-notes',
@@ -20,17 +19,15 @@ export class QuickNotesComponent implements OnInit {
   showloader: boolean = false
   showAddNote: boolean = false
   openEditNote: boolean = false
-  noNotes: boolean = true
   selectedNote: QuickNote;
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, public errorHandlerService: ErrorHandlerService, public popupHandlerService:PopupHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, public errorHandlerService: ErrorHandlerService) { }
 
   ngOnInit(): void {
   }
 
   showList() {
     this.showNotesList = true
-    this.showAddNote = false
     this.showloader = true
     const uid = this.authService.getLoggedInUser();
 
@@ -40,12 +37,6 @@ export class QuickNotesComponent implements OnInit {
       if(data) {
         this.notes = data;
       }
-      if(this.notes.length>0){
-        this.noNotes = false
-      }
-      else{
-        this.noNotes = true;
-      }
       this.showloader = false
       return data
     }));
@@ -53,7 +44,6 @@ export class QuickNotesComponent implements OnInit {
 
   openAddNote() {
     this.showNotesList = false
-    this.openEditNote= false;
     this.showAddNote = true
   }
 

--- a/src/app/services/popup-handler/popup-handler.service.ts
+++ b/src/app/services/popup-handler/popup-handler.service.ts
@@ -13,6 +13,8 @@ export class PopupHandlerService {
   addNewContributorEnabled: boolean = false
   parentTaskId: string = "default"
   parentTaskUrl: string = "default"
+  quickNotesTitle: string = ""
+  quickNotesDescription: string = ""
   
   constructor() { }
 
@@ -26,6 +28,8 @@ export class PopupHandlerService {
   resetTaskIds() {
     this.parentTaskId = "default"
     this.parentTaskUrl = "default"
+    this.quickNotesDescription = ""
+    this.quickNotesTitle = ""
   }
 
 }

--- a/src/app/services/popup-handler/popup-handler.service.ts
+++ b/src/app/services/popup-handler/popup-handler.service.ts
@@ -13,6 +13,8 @@ export class PopupHandlerService {
   addNewContributorEnabled: boolean = false
   parentTaskId: string = "default"
   parentTaskUrl: string = "default"
+  quickNotesTitle: string = ""
+  quickNotesDescription: string = ""
   
   constructor() { }
 
@@ -26,6 +28,9 @@ export class PopupHandlerService {
   resetTaskIds() {
     this.parentTaskId = "default"
     this.parentTaskUrl = "default"
+    this.quickNotesDescription = ""
+    this.quickNotesTitle = ""
+
   }
 
 }

--- a/src/app/services/popup-handler/popup-handler.service.ts
+++ b/src/app/services/popup-handler/popup-handler.service.ts
@@ -13,8 +13,6 @@ export class PopupHandlerService {
   addNewContributorEnabled: boolean = false
   parentTaskId: string = "default"
   parentTaskUrl: string = "default"
-  quickNotesTitle: string = ""
-  quickNotesDescription: string = ""
   
   constructor() { }
 
@@ -28,8 +26,6 @@ export class PopupHandlerService {
   resetTaskIds() {
     this.parentTaskId = "default"
     this.parentTaskUrl = "default"
-    this.quickNotesDescription = ""
-    this.quickNotesTitle = ""
   }
 
 }


### PR DESCRIPTION
### Functionality:

- Added Create a task in quick notes which opens the create new task modal with the given title and description of the quick note
- Added Create New Note in Edit quick note
- Made the changes to the quick notes saved if the user clicks create a task without saving it.

### Solution:

- Used Popuphandler service to display the modal
- Used Event emitter to open the addNote menu

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:

- Create a quick Note and click on create a task, check whether the given title and notes of the quickNote are in the Title and Description part of the Create New Task modal.
- Do the same for the edit notes.
- Check whether the notes are getting saved if you click create a task without saving the note.
- In the editNotes, on clicking the `+` icon it should open the empty add note.