### PR TITLE
fix(QuickNotes-Menu):Added Create A Task

### DIFF
--- a/src/app/body/create-new-task/create-new-task.component.ts
+++ b/src/app/body/create-new-task/create-new-task.component.ts
@@ -84,6 +84,8 @@ export class CreateNewTaskComponent implements OnInit {
     this.todayDate = this.toolsService.date();
     this.time = this.toolsService.time();
     this.parentTaskId = this.popupHandlerService.parentTaskId;
+    this.title = this.popupHandlerService.quickNotesTitle;		
+    this.description = this.popupHandlerService.quickNotesDescription;
   }
 
   private _filter(value: string): string[] {

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.css
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.css
@@ -40,4 +40,12 @@
   #icon {
       color: var(--text);
       cursor: pointer;
+      flex-grow: 0 !important;
   }
+  
+#create{
+  padding: 5px 0px 0px 0px;
+  cursor: pointer;
+  text-align: center;
+ }
+  

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.html
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.html
@@ -11,26 +11,29 @@
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
 * See the MIT License for more details. 
 ***********************************************************/ -->
-<div class="card" style="width: 36rem;">
+<div class="card" style="width: 36rem">
     <div class="card-header">
         <div class="row">
-            <div class="col 10">
-                <input type="text" class="form-control form-control-sm" [(ngModel)]="title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
+            <div class="col-8">
+                <input type="text" class="form-control form-control-sm" [(ngModel)]="title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title"/>
             </div>
-            <div class="col">
-                <mat-icon fontSet="material-icons" id="icon" class="float-right" (click)="close()">
+            <div class="col-3" id="create">
+                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
+            </div>
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" id="icon" class="float-right align-middle" (click)="close()">
                     close
                 </mat-icon>
             </div>
         </div>
     </div>
     <div class="card-body">
-        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="notesContent" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
+        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="notesContent" [ngModelOptions]="{ standalone: true }" placeholder="Write a note..."></textarea>
         <div class="row pt-4">
             <div class="col">
                 <button class="btn btn-success float-right" (click)="addNote()">save</button>
             </div>
         </div>
     </div>
-<app-loader *ngIf="enableLoader"></app-loader>
+    <app-loader *ngIf="enableLoader"></app-loader>
 </div>

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
@@ -26,7 +26,6 @@ import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handle
 export class AddnewNoteComponent implements OnInit {
 
   @Output() addNoteCompleted = new EventEmitter<boolean>();
-  @Output() showList = new EventEmitter();
 
   title: string = ""
   notesContent: string = ""

--- a/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
+++ b/src/app/body/quick-notes/addnew-note/addnew-note.component.ts
@@ -16,6 +16,7 @@ import { AngularFireFunctions } from '@angular/fire/compat/functions';
 import { map } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { ToolsService } from 'src/app/services/tool/tools.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 @Component({
   selector: 'app-addnew-note',
@@ -25,16 +26,25 @@ import { ToolsService } from 'src/app/services/tool/tools.service';
 export class AddnewNoteComponent implements OnInit {
 
   @Output() addNoteCompleted = new EventEmitter<boolean>();
+  @Output() showList = new EventEmitter();
 
   title: string = ""
   notesContent: string = ""
 
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService,public popupHandlerService: PopupHandlerService) { }
 
   ngOnInit(): void {
   }
+
+  createTask(){
+    this.popupHandlerService.createNewTaskEnabled= true;
+    this.popupHandlerService.resetTaskIds();
+    this.popupHandlerService.quickNotesTitle = this.title;
+    this.popupHandlerService.quickNotesDescription = this.notesContent;
+    this.addNote();
+    }
 
   addNote() {
     const uid = this.authService.getLoggedInUser();

--- a/src/app/body/quick-notes/edit-note/edit-note.component.css
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.css
@@ -40,4 +40,11 @@ input:focus {
 #icon {
     color: var(--text);
     cursor: pointer;
+    flex-grow: 0 !important;
+}
+
+#create{
+ padding: 5px 0px 0px 0px;
+ cursor: pointer;
+ text-align: center;
 }

--- a/src/app/body/quick-notes/edit-note/edit-note.component.html
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.html
@@ -12,25 +12,36 @@
 * See the MIT License for more details. 
 ***********************************************************/ -->
 <div class="card" style="width: 36rem;">
-  <div class="card-header">
-      <div class="row">
-          <div class="col-10">
-              <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title" [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
-          </div>
-          <div class="col">
-              <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
-                  close
-              </mat-icon>
-          </div>
-      </div>
-  </div>
-  <div class="card-body">
-          <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note" [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
-      <div class="row pt-4">
-          <div class="col">
-              <button class="btn btn-success float-right" (click)="saveNote()">save</button>
-          </div>
-      </div>
-  </div>
-  <app-loader *ngIf="enableLoader"></app-loader>
+    <div class="card-header">
+        <div class="row">
+            <div class="col-7">
+                <input type="text" class="form-control form-control-sm" [(ngModel)]="note.Title"
+                    [ngModelOptions]="{standalone: true}" placeholder="Enter Note Title">
+            </div>
+            <div class="col-3" id="create">
+                <a (click)="createTask()" data-toggle="modal" data-target="#createNewTask" title="Create a task with the given Title and Description">Create a Task</a>
+            </div>
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" title="Add New Note" class="float-right" id="icon" (click)="addNote()">
+                    add_box
+                </mat-icon>
+            </div>
+
+            <div class="col-1">
+                <mat-icon fontSet="material-icons" class="float-right" id="icon" (click)="close()">
+                    close
+                </mat-icon>
+            </div>
+        </div>
+    </div>
+    <div class="card-body">
+        <textarea type="text" class="form-control form-control-sm" rows="8" [(ngModel)]="note.Note"
+            [ngModelOptions]="{standalone: true}" placeholder="Write a note..."></textarea>
+        <div class="row pt-4">
+            <div class="col">
+                <button class="btn btn-success float-right" (click)="saveNote()">save</button>
+            </div>
+        </div>
+    </div>
+    <app-loader *ngIf="enableLoader"></app-loader>
 </div>

--- a/src/app/body/quick-notes/edit-note/edit-note.component.ts
+++ b/src/app/body/quick-notes/edit-note/edit-note.component.ts
@@ -19,6 +19,7 @@ import { ToolsService } from 'src/app/services/tool/tools.service';
 import { map, Observable } from 'rxjs';
 import { Router } from '@angular/router';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 
 @Component({
@@ -29,17 +30,27 @@ import { ErrorHandlerService } from 'src/app/services/error-handler/error-handle
 export class EditNoteComponent implements OnInit {
 
   @Output() editNoteCompleted = new EventEmitter<boolean>();
+  @Output() addNewNote = new EventEmitter();
   @Input('note') note: QuickNote;
   public quickNoteObservable: Observable<QuickNote>
   componentName:string = "QUICK-NOTES"
   editNote: QuickNote
   enableLoader: boolean = false
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, private toolService: ToolsService, private router: Router, public errorHandlerService: ErrorHandlerService,public popupHandlerService: PopupHandlerService) { }
 
   ngOnInit(): void {
     
   }
+
+  createTask(){
+    this.popupHandlerService.createNewTaskEnabled= true;
+    this.popupHandlerService.resetTaskIds();
+    this.popupHandlerService.quickNotesTitle = this.note.Title;
+    this.popupHandlerService.quickNotesDescription = this.note.Note;
+    this.saveNote();
+    }
+
 
   async saveNote() {
     const uid = this.authService.getLoggedInUser();
@@ -57,6 +68,10 @@ export class EditNoteComponent implements OnInit {
       console.error("Error", error);
     }
     this.editNoteCompleted.emit(true);
+  }
+
+  addNote(){
+    this.addNewNote.emit();
   }
 
   close() {

--- a/src/app/body/quick-notes/quick-notes.component.css
+++ b/src/app/body/quick-notes/quick-notes.component.css
@@ -12,6 +12,7 @@
 * See the MIT License for more details. 
 ***********************************************************/
 #quickNotesButton{
+    background:#5c60ec;
     display: block;
     border-radius:50px;
 	text-align:center;
@@ -28,9 +29,20 @@
     right: 30px;
     color: var(--text);
 }
+.card-body{
+    padding: 0.75rem 0.25rem !important;
+}
+.col{
+    flex-grow: 0 !important;
+}
+.noNotes{
+padding: auto;
+margin: auto;
+}
 
 #note {
     background-color: var(--secondary-bg);
+    border: none;
 }
 
 #note:hover {

--- a/src/app/body/quick-notes/quick-notes.component.html
+++ b/src/app/body/quick-notes/quick-notes.component.html
@@ -34,6 +34,7 @@
           <div class="card-body">
             <ul class="list-group list-group-flush">
                 <ng-container *ngIf="quickNoteObservable|async; else loader">
+                    <div *ngIf="noNotes;" class="noNotes">No notes Added</div>
                     <ng-container *ngFor="let item of notes">
                         <li class="list-group-item" id="note">
                             <div class="row">
@@ -63,7 +64,7 @@
 </ng-container>
 
 <ng-container *ngIf="showAddNote">
-    <app-addnew-note (addNoteCompleted)="addNoteCompleted($event)"></app-addnew-note>
+    <app-addnew-note (addNoteCompleted)="addNoteCompleted($event)" ></app-addnew-note>
 </ng-container>
 
 <ng-container *ngIf="openEditNote">

--- a/src/app/body/quick-notes/quick-notes.component.html
+++ b/src/app/body/quick-notes/quick-notes.component.html
@@ -68,5 +68,5 @@
 </ng-container>
 
 <ng-container *ngIf="openEditNote">
-    <app-edit-note [note]="selectedNote" (editNoteCompleted)="editNoteCompleted($event)"></app-edit-note>
+    <app-edit-note [note]="selectedNote" (editNoteCompleted)="editNoteCompleted($event)"(addNewNote)="openAddNote()"></app-edit-note>
 </ng-container>

--- a/src/app/body/quick-notes/quick-notes.component.ts
+++ b/src/app/body/quick-notes/quick-notes.component.ts
@@ -17,6 +17,7 @@ import { map, Observable } from 'rxjs';
 import { QuickNote } from 'src/app/Interface/UserInterface';
 import { AuthService } from 'src/app/services/auth.service';
 import { ErrorHandlerService } from 'src/app/services/error-handler/error-handler.service';
+import { PopupHandlerService } from 'src/app/services/popup-handler/popup-handler.service';
 
 @Component({
   selector: 'app-quick-notes',
@@ -33,14 +34,16 @@ export class QuickNotesComponent implements OnInit {
   showAddNote: boolean = false
   openEditNote: boolean = false
   selectedNote: QuickNote;
+  noNotes: boolean = true
 
-  constructor(private functions: AngularFireFunctions, public authService: AuthService, public errorHandlerService: ErrorHandlerService) { }
+  constructor(private functions: AngularFireFunctions, public authService: AuthService, public errorHandlerService: ErrorHandlerService, public popupHandlerService:PopupHandlerService) { }
 
   ngOnInit(): void {
   }
 
   showList() {
     this.showNotesList = true
+    this.showAddNote = false
     this.showloader = true
     const uid = this.authService.getLoggedInUser();
 
@@ -50,6 +53,12 @@ export class QuickNotesComponent implements OnInit {
       if(data) {
         this.notes = data;
       }
+      if(this.notes.length>0){
+        this.noNotes = false
+      }
+      else{
+        this.noNotes = true;
+      }
       this.showloader = false
       return data
     }));
@@ -57,6 +66,7 @@ export class QuickNotesComponent implements OnInit {
 
   openAddNote() {
     this.showNotesList = false
+    this.openEditNote= false;
     this.showAddNote = true
   }
 
@@ -98,4 +108,5 @@ export class QuickNotesComponent implements OnInit {
     this.showAddNote = false;
     this.openEditNote = false;
   }
+
 }

--- a/src/app/services/popup-handler/popup-handler.service.ts
+++ b/src/app/services/popup-handler/popup-handler.service.ts
@@ -27,6 +27,8 @@ export class PopupHandlerService {
   parentTaskId: string = "default"
   parentTaskUrl: string = "default"
   createPostEnabled: boolean = false
+  quickNotesTitle: string = ""
+  quickNotesDescription: string = ""
   
   constructor() { }
 
@@ -40,6 +42,8 @@ export class PopupHandlerService {
   resetTaskIds() {
     this.parentTaskId = "default"
     this.parentTaskUrl = "default"
+    this.quickNotesDescription = ""
+    this.quickNotesTitle = ""
   }
 
 }


### PR DESCRIPTION
### Functionality:

- Added Create A Task from Quick Notes
- Changed the colour of the quick notes button
- Made the recent changes to get saved if the user clicks creates a task before saving the changes.
- Added "No Notes Available if No Notes are available.
- Added "Create A Note" from the edit menu.

### Solution:

- Used PopUpHandlerService to Create A Task
- Used EventEmitter for toggling the AddNewTask

### Risk level:
- [x] high 
- [ ] medium
- [ ] low

### How to test:

- Check if "No Notes Available" is shown when no notes are added.
- Add a note and click create a task and check whether the title and description are shown in the respective input fields of the Create new task modal.
- Do the same for the EditNote
- In the edit note component click on the + icon and check whether it takes to the add new note Component.
- Click create a task without saving the changes and check whether the changes are saved.
