### PR TITLE
fix(CreateNewTask): added loader upon project change

### DIFF
--- a/src/app/body/create-new-task/create-new-task.component.ts
+++ b/src/app/body/create-new-task/create-new-task.component.ts
@@ -92,6 +92,7 @@ export class CreateNewTaskComponent implements OnInit {
   }
 
   readTeamData(teamId :string){
+    this.enableLoader = true;
     this.applicationSetting.getTeamDetails(teamId).subscribe(team => {
           this.priorityLabels = team.PriorityLabels;
           this.statusLabels = team.StatusLabels;
@@ -112,6 +113,7 @@ export class CreateNewTaskComponent implements OnInit {
             startWith(''),
             map(value => this._filter(value)),
           );
+          this.enableLoader = false;
     }); 
   }
   

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,20 +3,19 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-    production: false,
-    firebase: {
-  
-    },
-    useEmulators: true,
-    gitApiUrl: "https://api.github.com/repos/Worktez/worktez",
-    githubApiUrl: "https://api.github.com"
-  };
-  
-  /*
-   * For easier debugging in development mode, you can import the following file
-   * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
-   *
-   * This import should be commented out in production mode because it will have a negative impact
-   * on performance if an error is thrown.
-   */
+  production: false,
+  firebase: {
+  },
+  useEmulators: true,
+  gitApiUrl: "https://api.github.com/repos/Worktez/worktez",
+  githubApiUrl: "https://api.github.com"
+};
+
+/*
+ * For easier debugging in development mode, you can import the following file
+ * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
+ *
+ * This import should be commented out in production mode because it will have a negative impact
+ * on performance if an error is thrown.
+ */
   // import 'zone.js/plugins/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
### Functionality:
Project change should fetch particular team details after loader appears

### Solution:
Loader added to notify the user when project is switched from dropdown

### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
Go to Create Task popup and switch between projects to see loader
