### PR TITLE
fixed(speed-images):fixed the  allignment of speed images

### DIFF
--- a/src/app/body/view-organization-details/teams-card/teams-card.component.html
+++ b/src/app/body/view-organization-details/teams-card/teams-card.component.html
@@ -15,7 +15,6 @@
     <div class="card-body pt-4">
         <div class="row">
             <div class="col-3 ml-4 mb-4">
-                <app-speed-images [emails]="team.TeamMembers.slice(0,3)"></app-speed-images>
             </div>
             <div class="dropdown">
                 <button class="btn btn-primary" *ngIf="projectLinked" type="button" data-bs-toggle="tooltip" data-bs-placement="top"


### PR DESCRIPTION
### Functionality:
Speed images won't be overlapping in teams card
### Solution:
Changes in speed-images component
### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
<-- steps for testing:
1. ng serve
2. firebase emulators:start
3. go to My Organisation.
4. then scroll down the page.
5. you can see the speed images won't be overlaping the footer.
6. bug fixed!
  -->
