### PR TITLE
fix (create new sprint reload):closing the popup without creating the spring, the whole page reloads

### DIFF
--- a/src/app/body/create-new-sprint/create-new-sprint.component.html
+++ b/src/app/body/create-new-sprint/create-new-sprint.component.html
@@ -74,7 +74,7 @@
                         <div class="row pt-2">
                             <div class="col-md-4"></div>
                             <div class="col-md-4 pt-2 px-4">
-                                <button class="btn btn-secondary" type="button" data-dismiss="modal" (click)="close()">Close</button>
+                                <button class="btn btn-secondary" type="button" data-dismiss="modal" (click)="close();load()">Close</button>
                             </div>
                             <div class="col-md-4"></div>
                         </div>

--- a/src/app/body/create-new-sprint/create-new-sprint.component.ts
+++ b/src/app/body/create-new-sprint/create-new-sprint.component.ts
@@ -100,7 +100,9 @@ export class CreateNewSprintComponent implements OnInit {
       this.showContent = true;
     });
   }
-
+  load(){
+    window.location.reload();
+  }
   async submit() {
     let data = [{ label: "startDate", value: this.startDate },
     { label: "endDate", value: this.endDate },
@@ -140,7 +142,7 @@ export class CreateNewSprintComponent implements OnInit {
   close() {
     jQuery('#createNewSprint').modal('hide');
     jQuery('#form').trigger("reset");
-    window.location.reload();
+    // window.location.reload();
     this.sprintCreated.emit({ completed: true });
   }
 }


### PR DESCRIPTION
### Functionality:
fix (create new sprint reload):closing the popup without creating the spring, the whole page reloads

### Solution:
Changes in create-new-sprint-component

### Risk level:
- [ ] high 
- [ ] medium
- [ x] low

### How to test:
 clicking on create new sprint, and then closing the popup without creating the spring, the whole page is not reloading now
