### PR TITLE
Fix create new team popup

### DIFF
--- a/src/app/body/create-new-team/create-new-team.component.ts
+++ b/src/app/body/create-new-team/create-new-team.component.ts
@@ -161,6 +161,6 @@ export class CreateNewTeamComponent implements OnInit {
   }
 
   close() {
-    this.router.navigate(['MyDashboard']);
+    this.router.navigate(['ViewOrganizationDetails']);
   }
 }


### PR DESCRIPTION
### Functionality:
<--close button of create new team redirects to view organization details-->

### Solution:
<--changed the close function navigation from mydashboard to vieworganizationdetails -->

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:
<--Steps to check the functionality
1. ng serve
2. firebase emulators:start
3. go to my organization
4. click on create new team icon
5. click on close button
6. will redirect to organization details instead of my dashboard. -->
