### PR TITLE
Fix create new task popup

### DIFF
--- a/src/app/body/create-new-task/create-new-task.component.html
+++ b/src/app/body/create-new-task/create-new-task.component.html
@@ -30,7 +30,7 @@
                         <div class="col">
                             {{ todayDate }}
                         </div>
-                        <div class="col d-flex justify-content-end">
+                        <div class="col d-flex justify-content-end" *ngIf="!showClose" >
                             <span id="Active" class="p-2 m-2" (click)="activeSprint()" *ngIf="sprintNumber!=currentSprintNumber">Active Sprint</span>
                             <span id="Backlog" class="p-2 m-2" (click)="showBacklog()" *ngIf="sprintNumber!=backlogSprintNumber">Backlog</span>
                         </div>


### PR DESCRIPTION
### Functionality:
<--Sprint number button is removed from task creation succession popup -->

### Solution:
<--Added ngIf to hide the buttons from  task creation succession popup  -->

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:
<-- Steps to test functionality/bug:
1. ng serve & firebase emulators:start
2. go to create new task
3. create task
4. active sprint button will not be displayed in task creation succession popup. -->
