### PR TITLE
Fix/kanban board: fixed the filter

### DIFF
--- a/src/app/body/kanban-board/kanban-board.component.ts
+++ b/src/app/body/kanban-board/kanban-board.component.ts
@@ -84,6 +84,8 @@ export class KanbanBoardComponent implements OnInit {
     this.applicationSettingsService.editedTeamId = teamId;
     this.startService.selectedTeamId = teamId;
     this.authService.userAppSetting.SelectedTeamId = teamId;
+    this.startService.readApplicationData();
+    this.filterSprintNumber = this.startService.currentSprintNumber;
     this.startService.changeTeam = true;
     this.sprintNotExist = false;
     this.showContent = false;


### PR DESCRIPTION
### Functionality:
on switching teams, the sprint number is not changing itself

### Solution:
Updated the sprint number in startservice

### Risk level:
- [ ] high 
- [ ] medium
- [X] low

### How to test:
By changing the teamID
