### PR TITLE
Fix(Kanban-board): fixed the reload

### DIFF
--- a/src/app/body/kanban-board/kanban-board.component.ts
+++ b/src/app/body/kanban-board/kanban-board.component.ts
@@ -146,6 +146,7 @@ export class KanbanBoardComponent implements OnInit {
   }
 
   putDataInTasksArray(tasksData: Tasks[]) {
+    this.tasks = [];
     this.selectedStatusLabels.forEach((label) => {
       let tasksarr = [];
       tasksData.forEach((task) => {


### PR DESCRIPTION
### Functionality:
While switching teams more than once, and reloading the page, the whole layout changes

### Solution:
Emptied the array when function hits more than once

### Risk level:
- [ ] high 
- [X] medium
- [ ] low

### How to test:
switch teams more than once, and then reload the page simultaneously
