### PR TITLE
fix/EditProfileReload

### DIFF
--- a/src/app/body/profile/edit-profile/edit-profile.component.ts
+++ b/src/app/body/profile/edit-profile/edit-profile.component.ts
@@ -88,7 +88,6 @@ export class EditProfileComponent implements OnInit {
 
   editProfileDone() {
     this.editProfileCompleted.emit({ completed: true });
-    window.location.reload()
   }
 
   async checkAvailability() {


### PR DESCRIPTION
### Functionality:
When Edit profile modal is closed without doing any changes it automatically reloaded the page.

### Solution:
removed the window.location.reload functionality so now the window wont automatically reload.

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:
Close the edit profile modal popup to check if it doesn't automatically reload.
