### PR TITLE
Fix/editProfileAccess

### DIFF
--- a/src/app/body/profile/profile.component.ts
+++ b/src/app/body/profile/profile.component.ts
@@ -105,8 +105,16 @@ export class ProfileComponent implements OnInit {
         }
       });
     }
+    this.checkSameUser();
   }
-
+  checkSameUser(){
+    if (this.authService.userAppSetting.Username == this.username){
+      this.sameUser=true;
+    }
+    else{
+      this.sameUser=false;
+    }
+  }
   editProfile() {
     this.editProfileEnabled = true;
   }


### PR DESCRIPTION
### Functionality:
Edit Profile page will now be accessible by only the user itself and not by other user

### Solution:
Added checkSameUser() function in profile.component.ts

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:
Go to some other users profile and try to edit 