### PR TITLE
Fixed upcoming sprint bucket on load more

### DIFF
--- a/src/app/body/home/home.component.html
+++ b/src/app/body/home/home.component.html
@@ -33,7 +33,7 @@
             <div class="col pt-5">
                 <div id="showContent">
                     <h1 id="headingLine">
-                        Simpilfy and organize the way teams work. 
+                        Simplify and organize the way teams work. 
                     </h1>
                     <p id="headingLine2">Track it, from everywhere. One step to hybrid work environment. Without worrying about time, and location. Enable your team to work more on ideas, and automate the process.</p>
                     <br/>

--- a/src/app/body/tasks-evaluation/tasks-evaluation.component.ts
+++ b/src/app/body/tasks-evaluation/tasks-evaluation.component.ts
@@ -130,7 +130,9 @@ export class TasksEvaluationComponent implements OnInit {
           if (result.BacklogTasks.length > 0) {
             this.tasks.push(result.BacklogTasks);
           }
-          this.upcomingSprintTasks.push(result.UpcomingSprintTasks);
+          if(pageToLoad == "initial"){
+            this.upcomingSprintTasks.push(result.UpcomingSprintTasks);
+          }
           this.tasks.push(result.Tasks);
           this.nextSprintTasksToFetch -= 1;
           if (this.nextSprintTasksToFetch < 1) {


### PR DESCRIPTION
### Functionality
Fixed the Upcoming sprint bucket on task evaluation page

### Solution:
When clicked on load more the upcoming sprint bucket was increasing. Fixed that

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:
Try clicking on load more and check whether the upcoming sprint bucket is visible only once