### PR TITLE
fix(git-icon ): "fixed github icon in task details page"

### DIFF
--- a/src/app/body/task-details/task-details.component.html
+++ b/src/app/body/task-details/task-details.component.html
@@ -50,7 +50,7 @@
                     </div>
                     <div class="col-md-6 col-6 py-2 d-flex justify-content-end">
                         <ul class="nav">
-                            <li class="nav-item">
+                            <li class="nav-item" *ngIf="gitRepoExists">
                                 <span class="btn">
                                     <img src="../../../assets/git.png" *ngIf="!prLinked" height="25" class="rounded-circle" width="25"
                                     alt="user" data-toggle="modal" title="Select PR" data-target="#gitPrModel" (click)="linkPr()">

--- a/src/app/body/task-details/task-details.component.ts
+++ b/src/app/body/task-details/task-details.component.ts
@@ -90,7 +90,8 @@ export class TaskDetailsComponent implements OnInit {
   loggedTimeMins: number;
   totalRemainingTime: number;
   remainingTimeHrs: number;
-  remainingTimeMins: number
+  remainingTimeMins: number;
+  gitRepoExists: boolean = false;
 
 
   constructor (private httpService: HttpServiceService,public rbaService: RBAService, public startService: StartServiceService, public applicationSettingService: ApplicationSettingsService, private route: ActivatedRoute, private functions: AngularFireFunctions, public authService: AuthService, private location: Location, public toolsService: ToolsService, private navbarHandler: NavbarHandlerService, public errorHandlerService: ErrorHandlerService, private backendService: BackendService, public cloneTask: CloneTaskService,public userService:UserServiceService,public popupHandlerService: PopupHandlerService, public validationService: ValidationService ) { }
@@ -107,6 +108,15 @@ export class TaskDetailsComponent implements OnInit {
 
     this.navbarHandler.addToNavbar( this.Id );
     this.getTaskPageData();
+  }
+
+  checkGithubRepo(){
+    this.applicationSettingService.getTeamDetails(this.task.TeamId).subscribe(data => {
+      if(data.ProjectLink != undefined && data.ProjectLink != ""){
+          this.gitRepoExists=true;
+          this.checkPrLinked();
+      }
+    });
   }
   
   checkPrLinked(){
@@ -163,7 +173,7 @@ export class TaskDetailsComponent implements OnInit {
       next: (data) => {
         this.task = data;
         this.getTimeDetails();
-        this.checkPrLinked()
+        this.checkGithubRepo();
         if (this.task.Watcher.includes(this.newWatcher)) {
           this.addedWatcher = true;
         }


### PR DESCRIPTION
Signed-off-by: Aashi <aashichaudhary4403@gmail.com>

### Functionality:
To show github icon in task details page only when repository is linked

### Solution:
fixed the github icon to only appear when the repository is linked to a particular team

### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
Step 1. Link a repository for a team
Step 2. Check any of that team's tasks if github icon appear
