### PR TITLE
Fixed:Add members

### DIFF
--- a/src/app/body/create-new-team/add-member/add-member.component.ts
+++ b/src/app/body/create-new-team/add-member/add-member.component.ts
@@ -55,7 +55,7 @@ export class AddMemberComponent implements OnInit {
     });
 
     if (condition) {
-      if (this.memberEmail) {
+      if (!this.teamMembers.includes(this.memberEmail)) {
         this.teamMembers.push(this.memberEmail);
         if (this.isUpdateTeam == true) {
           this.addUpdateTeam();


### PR DESCRIPTION
### Functionality:
Same Member email was added more than one time.

### Solution:
Now Unable to add same member more than one time

## WtId:


### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
Go to Add members and try adding two emails same time.