### PR TITLE
fix sprint details for previous sprint

### DIFF
--- a/src/app/body/board/sprint-details/sprint-details.component.ts
+++ b/src/app/body/board/sprint-details/sprint-details.component.ts
@@ -51,7 +51,10 @@ export class SprintDetailsComponent implements OnInit {
   constructor(public startService: StartServiceService,public rbaService: RBAService, private authService: AuthService, public applicationSettingsService: ApplicationSettingsService, public toolsService: ToolsService, private functions: AngularFireFunctions, public errorHandlerService: ErrorHandlerService, public backendService: BackendService, private router: Router,public popupHandlerService: PopupHandlerService) { }
 
   ngOnInit(): void {
-    this.todayDate = this.toolsService.date();
+    this.todayDate = this.toolsService.date().split('-').reverse().join('-');
+    if(this.sprintData.Status == 'Completed'){
+      this.workPercentage = 100;
+    }
     this.applicationSettingsService.sprintDataObservable.subscribe((data) => {
       this.sprintDataReady = true;
       if(this.startService.currentSprintNumber == 0){
@@ -86,7 +89,7 @@ export class SprintDetailsComponent implements OnInit {
           this.sprintData = data;
           this.showLoader = false;
           if(sprintStatus=='Completed'){
-            this.sprintData.EndDate=  this.todayDate = this.toolsService.date().split('/').reverse().join('-');
+            this.sprintData.EndDate=  this.todayDate;
             this.workPercentage=100;
           
           }


### PR DESCRIPTION
### Functionality:
end Date format was not correct and workpercentage was not correct

### Solution:
make end Date in right format and workpercentage as 100% when status is completed

## WtId:
Dev634

### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
going into board and changing sprint number
