### PR TITLE
Istant data set on kanban board

### DIFF
--- a/src/app/body/kanban-board/kanban-board.component.ts
+++ b/src/app/body/kanban-board/kanban-board.component.ts
@@ -190,11 +190,11 @@ export class KanbanBoardComponent implements OnInit {
       moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
       this.showLoader = false;
     } else {
+      transferArrayItem(event.previousContainer.data, event.container.data, event.previousIndex, event.currentIndex);
       this.editTask(event.previousContainer.data[event.previousIndex], status).subscribe({
         next: (data) => {
           result = data;
           if (result == "OK") {
-            transferArrayItem(event.previousContainer.data, event.container.data, event.previousIndex, event.currentIndex);
             this.showLoader = false;
           }
         },


### PR DESCRIPTION
### Functionality:
Upon drag the data change takes time to reflect as new data.

### Solution:
Improve implementation to update local data instantly, without waiting to update db

## WtId:
Dev667

### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
Go into kanban board, drag and drop
